### PR TITLE
Convert priorities to use ratings out of 5

### DIFF
--- a/app/Http/Livewire/Modals/PriorityDetails.php
+++ b/app/Http/Livewire/Modals/PriorityDetails.php
@@ -26,13 +26,13 @@ class PriorityDetails extends Component
         ;
     }
 
-    public function shortlist(Film $film, string $level, string $comment)
+    public function shortlist(Film $film, int $rating, string $comment)
     {
         Auth::user()
             ->priorities()
             ->updateOrCreate(
                 ['film_id' => $film->id],
-                ['level' => $level, 'comment' => $comment]
+                ['rating' => $rating, 'comment' => $comment]
             )
         ;
 

--- a/app/Models/Priority.php
+++ b/app/Models/Priority.php
@@ -10,16 +10,6 @@ class Priority extends Model
 {
     use HasFactory;
 
-    public const LOW = 'low';
-    public const MEDIUM = 'medium';
-    public const HIGH = 'high';
-    
-    public const LEVELS = [
-        self::LOW => 'low',
-        self::MEDIUM => 'medium',
-        self::HIGH => 'high',
-    ];
-    
     /** @var array */
     protected $guarded = [];
 

--- a/database/factories/PriorityFactory.php
+++ b/database/factories/PriorityFactory.php
@@ -17,7 +17,7 @@ class PriorityFactory extends Factory
         return [
             'user_id' => User::factory(),
             'film_id' => Film::factory(),
-            'level' => Priority::LEVELS[array_rand(Priority::LEVELS)],
+            'rating' => $this->faker->numberBetween(1, 5),
             'comment' => $this->faker->sentence,
         ];
     }

--- a/database/migrations/2021_06_19_130759_create_priorities_table.php
+++ b/database/migrations/2021_06_19_130759_create_priorities_table.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\Priority;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
@@ -18,7 +17,7 @@ class CreatePrioritiesTable extends Migration
             $table->foreignId('film_id')->constrained('films')->cascadeOnDelete();
 
             // Data
-            $table->enum('level', Priority::LEVELS);
+            $table->integer('rating');
             $table->text('comment')->nullable();
 
             $table->timestamps();

--- a/resources/views/livewire/modals/priority-details.blade.php
+++ b/resources/views/livewire/modals/priority-details.blade.php
@@ -1,31 +1,16 @@
-<div x-data="{ level: '{{ $priority['level'] ?? 'low' }}', comment: '{{ $priority['comment'] ?? '' }}' }">
+<div x-data="{ rating: '{{ $priority['rating'] ?? '1' }}', comment: '{{ $priority['comment'] ?? '' }}' }">
     <h1 class="text-center font-bold text-lg">{{ $film['title']}}</h1>
-    <h2 class="text-center">Set priority</h2>
+    
+    <div>
+        <h2 class="text-center">Set rating</h2>
 
-    <div class="flex justify-stretch mt-2">
-        <button 
-            class="w-1/3 bg-blue-200 hover:bg-blue-300"
-            x-bind:class="{ 'border-2': level === 'low', 'border-blue-400': level === 'low', 'font-bold': level === 'low' }"
-            @click="level = 'low'"
-        >
-            Low
-        </button>
-
-        <button 
-            class="w-1/3 bg-yellow-300 hover:bg-yellow-400"
-            x-bind:class="{ 'border-2': level === 'medium', 'border-yellow-500': level === 'medium', 'font-bold': level === 'medium' }"
-            @click="level = 'medium'"
-        >
-            Medium
-        </button>
-
-        <button 
-            class="w-1/3 bg-red-600 hover:bg-red-700"
-            x-bind:class="{ 'border-2': level === 'high', 'border-red-800': level === 'high', 'font-bold': level === 'high' }"
-            @click="level = 'high'"
-        >
-            High
-        </button>
+        <select name="ratings" id="ratings" x-model="rating">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+        </select>
     </div>
 
     <div>
@@ -39,7 +24,7 @@
             Cancel
         </button>
         
-        <button x-on:click="$wire.shortlist({{ $film['id'] }}, level, comment); $parent.close()">
+        <button x-on:click="$wire.shortlist({{ $film['id'] }}, rating, comment); $parent.close()">
             Save
         </button>
     </div>

--- a/resources/views/livewire/shortlist.blade.php
+++ b/resources/views/livewire/shortlist.blade.php
@@ -10,7 +10,7 @@
             @foreach ($films as $film)
                 <div class="mt-4 border" wire:key="{{ $loop->index }}">
                     <div class="font-bold text-lg">{{ $film->title }}</div>
-                    <div>Level - {{$film->priorities->first()->level }}</div>
+                    <div>Rating - {{$film->priorities->first()->rating }}</div>
                     <div>{{$film->priorities->first()->comment }}</div>
 
                     <div>

--- a/tests/Feature/AddShortlistPriorityDetailsTest.php
+++ b/tests/Feature/AddShortlistPriorityDetailsTest.php
@@ -6,7 +6,6 @@ use Tests\TestCase;
 use App\Models\Film;
 use App\Models\User;
 use Livewire\Livewire;
-use App\Models\Priority;
 use App\Http\Livewire\Modals\PriorityDetails;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -22,7 +21,7 @@ class AddShortlistPriorityDetailsTest extends TestCase
 
         Livewire::actingAs($user)
             ->test(PriorityDetails::class, ['data' => ['film' => $film->toArray()]])
-            ->call('shortlist', $film, Priority::HIGH, 'A comment')
+            ->call('shortlist', $film, 5, 'A comment')
         ;
 
         $this->assertEmpty($user->filmsToShortlist);
@@ -37,7 +36,7 @@ class AddShortlistPriorityDetailsTest extends TestCase
 
         Livewire::actingAs($user)
             ->test(PriorityDetails::class, ['data' => ['film' => $film->toArray()]])
-            ->call('shortlist', $film, Priority::HIGH, 'A comment')
+            ->call('shortlist', $film, 5, 'A comment')
         ;
 
         $this->assertCount(1, $user->priorities);
@@ -45,7 +44,7 @@ class AddShortlistPriorityDetailsTest extends TestCase
         $priority = $user->priorities->first();
 
         $this->assertEquals($film->id, $priority->film_id);
-        $this->assertEquals(Priority::HIGH, $priority->level);
+        $this->assertEquals(5, $priority->rating);
         $this->assertEquals('A comment', $priority->comment);
     }
 
@@ -58,7 +57,7 @@ class AddShortlistPriorityDetailsTest extends TestCase
         $user->priorities()
             ->create([
                 'film_id' => $film->id,
-                'level' => PRIORITY::LOW,
+                'rating' => 1,
                 'comment' => 'First comment',
             ])
         ;
@@ -78,14 +77,14 @@ class AddShortlistPriorityDetailsTest extends TestCase
         $user->priorities()
             ->create([
                 'film_id' => $film->id,
-                'level' => PRIORITY::LOW,
+                'rating' => 1,
                 'comment' => 'First comment',
             ])
         ;
 
         Livewire::actingAs($user)
             ->test(PriorityDetails::class, ['data' => ['film' => $film->toArray()]])
-            ->call('shortlist', $film, Priority::HIGH, 'Second comment')
+            ->call('shortlist', $film, 5, 'Second comment')
         ;
 
         $this->assertCount(1, $user->priorities);
@@ -93,7 +92,7 @@ class AddShortlistPriorityDetailsTest extends TestCase
         $priority = $user->priorities->first();
 
         $this->assertEquals($film->id, $priority->film_id);
-        $this->assertEquals(Priority::HIGH, $priority->level);
+        $this->assertEquals(5, $priority->rating);
         $this->assertEquals('Second comment', $priority->comment);
     }
 }

--- a/tests/Feature/RemoveFromShortlistTest.php
+++ b/tests/Feature/RemoveFromShortlistTest.php
@@ -6,7 +6,6 @@ use Tests\TestCase;
 use App\Models\Film;
 use App\Models\User;
 use Livewire\Livewire;
-use App\Models\Priority;
 use App\Http\Livewire\Modals\RemoveFromShortlist;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -30,7 +29,7 @@ class RemoveFromShortlistTest extends TestCase
         $user->priorities()
             ->create([
                 'film_id' => $film->id,
-                'level' => PRIORITY::LOW,
+                'rating' => 1,
                 'comment' => 'First comment',
             ])
         ;
@@ -60,7 +59,7 @@ class RemoveFromShortlistTest extends TestCase
         $user->priorities()
             ->create([
                 'film_id' => $film->id,
-                'level' => PRIORITY::LOW,
+                'rating' => 1,
                 'comment' => 'First comment',
             ])
         ;
@@ -89,7 +88,7 @@ class RemoveFromShortlistTest extends TestCase
         $user->priorities()
             ->create([
                 'film_id' => $film->id,
-                'level' => PRIORITY::LOW,
+                'rating' => 1,
                 'comment' => 'First comment',
             ])
         ;

--- a/tests/Feature/ShowShortlistedFilmsTest.php
+++ b/tests/Feature/ShowShortlistedFilmsTest.php
@@ -6,7 +6,6 @@ use Tests\TestCase;
 use App\Models\Film;
 use App\Models\User;
 use Livewire\Livewire;
-use App\Models\Priority;
 use App\Http\Livewire\Shortlist;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -42,7 +41,7 @@ class ShowShortlistedFilmsTest extends TestCase
         $user = User::factory()->create();
 
         $user->films()->updateExistingPivot($shortlistedFilm, ['status' => Film::SHORTLISTED]);
-        $user->priorities()->create(['film_id' => $shortlistedFilm->id, 'level' => Priority::MEDIUM]);
+        $user->priorities()->create(['film_id' => $shortlistedFilm->id, 'rating' => 3]);
 
         $response = Livewire::actingAs($user)->test(Shortlist::class);
 

--- a/tests/Unit/FilmTest.php
+++ b/tests/Unit/FilmTest.php
@@ -97,8 +97,8 @@ class FilmTest extends TestCase
 
         $film = Film::factory()->create();
 
-        $userA->priorities()->save(new Priority(['film_id' => $film->id, 'level' => Priority::MEDIUM]));
-        $userB->priorities()->save(new Priority(['film_id' => $film->id, 'level' => Priority::MEDIUM]));
+        $userA->priorities()->save(new Priority(['film_id' => $film->id, 'rating' => 3]));
+        $userB->priorities()->save(new Priority(['film_id' => $film->id, 'rating' => 3]));
 
         $this->assertCount(2, $film->priorities);
     }

--- a/tests/Unit/PriorityTest.php
+++ b/tests/Unit/PriorityTest.php
@@ -19,7 +19,7 @@ class PriorityTest extends TestCase
     {
         $this->assertTrue(
             Schema::hasColumns('priorities', [
-                'id', 'user_id', 'film_id', 'level', 'comment',
+                'id', 'user_id', 'film_id', 'rating', 'comment',
             ])
         );
     }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -128,8 +128,8 @@ class UserTest extends TestCase
         $filmA = Film::factory()->create();
         $filmB = Film::factory()->create();
 
-        $filmA->priorities()->save(new Priority(['user_id' => $user->id, 'level' => Priority::MEDIUM]));
-        $filmB->priorities()->save(new Priority(['user_id' => $user->id, 'level' => Priority::MEDIUM]));
+        $filmA->priorities()->save(new Priority(['user_id' => $user->id, 'rating' => 3]));
+        $filmB->priorities()->save(new Priority(['user_id' => $user->id, 'rating' => 3]));
 
         $this->assertCount(2, $user->priorities);
     }


### PR DESCRIPTION
This brings them inline with the way reviews are scored, which will allow the two values to be compared.